### PR TITLE
use relative instead of abs path for wahrcade modals

### DIFF
--- a/docs/puzzle/wahrcade.html
+++ b/docs/puzzle/wahrcade.html
@@ -226,7 +226,7 @@
     }
 
     $(".wahrcade_slide").click(function() {
-      $('#modalContent').attr('src', `/static/puzzle_resources/wahrcade/${$(this).data("slide")}.png`);
+      $('#modalContent').attr('src', `../static/puzzle_resources/wahrcade/${$(this).data("slide")}.png`);
     });
 
 


### PR DESCRIPTION
For some reason the absolute path worked locally, but not on github.io.